### PR TITLE
Renamed components of drug card for clarity and brevity

### DIFF
--- a/app/src/main/java/com/pillpals/pillbuddies/ui/DrugCard.kt
+++ b/app/src/main/java/com/pillpals/pillbuddies/ui/DrugCard.kt
@@ -17,13 +17,14 @@ class DrugCard : LinearLayout {
     private val VIEW_NOT_CHANGED = false
     private val DEFAULT_COLOR = Color.DKGRAY
 
-    public lateinit var medicationDueText: TextView
-    public lateinit var medicationLateText: TextView
-    public lateinit var medicationNameText: TextView
-    public lateinit var medicationLogButton: MaterialButton
-    public lateinit var medicationCountdownLabel: TextView
     public lateinit var drugCard: CardView
-    public lateinit var medicationDoneImage: ImageView
+    public lateinit var nameText: TextView
+    public lateinit var altText: TextView
+    public lateinit var lateText: TextView
+    public lateinit var button: MaterialButton
+    public lateinit var countdownLabel: TextView
+    public lateinit var icon: ImageView
+    public lateinit var doneImage: ImageView
 
     companion object {
         private var mSquareColor: Int = 0
@@ -52,19 +53,19 @@ class DrugCard : LinearLayout {
 
         //Get references to elements
         drugCard = findViewById(R.id.LogCard)
-        medicationDueText  = findViewById(R.id.medicationDue)
-        medicationLateText  = findViewById(R.id.medicationLate)
-        medicationNameText  = findViewById(R.id.medicationName)
-        medicationLogButton  = findViewById(R.id.logButton)
-        medicationCountdownLabel = findViewById(R.id.medicationCountdownLabel)
-        medicationDoneImage = findViewById(R.id.medicationDoneImage)
-        medicationDoneImage = findViewById(R.id.medicationDoneImage)
+        altText  = findViewById(R.id.altText)
+        lateText  = findViewById(R.id.lateText)
+        nameText  = findViewById(R.id.nameText)
+        button  = findViewById(R.id.button)
+        countdownLabel = findViewById(R.id.countdownLabel)
+        icon = findViewById(R.id.icon)
+        doneImage = findViewById(R.id.doneImage)
 
         //Initialize elements
-        medicationLogButton.visibility = GONE
-        medicationDoneImage.visibility = GONE
-        medicationCountdownLabel.visibility = GONE
-        medicationLateText.visibility = GONE
+        button.visibility = GONE
+        doneImage.visibility = GONE
+        countdownLabel.visibility = GONE
+        lateText.visibility = GONE
     }
 
     override fun onDraw(canvas: Canvas) {

--- a/app/src/main/java/com/pillpals/pillbuddies/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/pillpals/pillbuddies/ui/dashboard/DashboardFragment.kt
@@ -4,12 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import com.pillpals.pillbuddies.R
-import androidx.appcompat.app.AppCompatActivity
 import android.widget.LinearLayout
 import io.realm.Realm
 import io.realm.RealmObject
@@ -21,15 +17,9 @@ import java.util.UUID
 import java.util.Date
 import java.util.Calendar
 import com.pillpals.pillbuddies.helpers.DateHelper
-import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Color
-import android.util.AttributeSet
 
-import com.google.android.material.button.MaterialButton
 import android.util.Log
 import com.pillpals.pillbuddies.ui.DrugCard
-import kotlinx.android.synthetic.main.drug_card.view.*
 
 class DashboardFragment : Fragment() {
 
@@ -97,15 +87,15 @@ class DashboardFragment : Fragment() {
     }
 
     private fun addDrugCard(schedule: Schedules, medication: Medications) {
-        var new = DrugCard(this.context!!)
+        var newCard = DrugCard(this.context!!)
 
-        new.medicationNameText.text = medication.name
-        new.medicationDueText.text = DateHelper.dateToString(schedule.occurrence!!)
+        newCard.nameText.text = medication.name
+        newCard.altText.text = DateHelper.dateToString(schedule.occurrence!!)
         val diff = schedule.occurrence!!.time - Date().time
         val seconds = diff / 1000
-        new.medicationCountdownLabel.text = DateHelper.secondsToCountdown(seconds)
+        newCard.countdownLabel.text = DateHelper.secondsToCountdown(seconds)
 
-        new.medicationLogButton.setOnClickListener {
+        newCard.button.setOnClickListener {
             drugLogFunction(schedule)
             update()
         }
@@ -121,24 +111,24 @@ class DashboardFragment : Fragment() {
         val currentLog = schedule.logs.filter { it.due == schedule.occurrence }
         if (currentLog.count() > 0) {
             // Completed
-            new.medicationDoneImage.setVisibility(LinearLayout.VISIBLE)
-            new.drugCard.setCardBackgroundColor(this.resources.getColor(R.color.colorGrey))
-            completedStack.addView(new)
+            newCard.doneImage.setVisibility(LinearLayout.VISIBLE)
+            newCard.drugCard.setCardBackgroundColor(this.resources.getColor(R.color.colorGrey))
+            completedStack.addView(newCard)
         }
         else if (currentDate.time >= schedule.occurrence!!) {
             // Current
-            new.logButton.setVisibility(LinearLayout.VISIBLE)
+            newCard.button.setVisibility(LinearLayout.VISIBLE)
             if (lateDate.time >= schedule.occurrence!!) {
-                new.medicationLateText.setVisibility(LinearLayout.VISIBLE)
+                newCard.lateText.setVisibility(LinearLayout.VISIBLE)
             }
-            new.drugCard.setCardBackgroundColor(this.resources.getColor(R.color.colorWhite))
-            currentStack.addView(new)
+            newCard.drugCard.setCardBackgroundColor(this.resources.getColor(R.color.colorWhite))
+            currentStack.addView(newCard)
         }
         else {
             // Upcoming
-            new.medicationCountdownLabel.setVisibility(LinearLayout.VISIBLE)
-            new.drugCard.setCardBackgroundColor(this.resources.getColor(R.color.colorWhite))
-            upcomingStack.addView(new)
+            newCard.countdownLabel.setVisibility(LinearLayout.VISIBLE)
+            newCard.drugCard.setCardBackgroundColor(this.resources.getColor(R.color.colorWhite))
+            upcomingStack.addView(newCard)
         }
     }
 
@@ -172,7 +162,7 @@ class DashboardFragment : Fragment() {
         val testCards = Array(n) { DrugCard(getContext()!!) }
 
         for (i in testCards.indices) {
-            testCards[i].medicationNameText.text = "Medication ${i + 1}"
+            testCards[i].nameText.text = "Medication ${i + 1}"
             when(i % 3) {
                 0 -> currentStack.addView(testCards[i])
                 1 -> completedStack.addView(testCards[i])

--- a/app/src/main/java/com/pillpals/pillbuddies/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/pillpals/pillbuddies/ui/home/HomeFragment.kt
@@ -7,12 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.pillpals.pillbuddies.R
 import com.pillpals.pillbuddies.data.model.Medications
-import com.pillpals.pillbuddies.data.model.Schedules
-import com.pillpals.pillbuddies.helpers.DatabaseHelper
 import com.pillpals.pillbuddies.ui.AddDrugActivity
 import com.pillpals.pillbuddies.ui.DrugCard
 import io.realm.Realm
@@ -88,19 +85,19 @@ class HomeFragment : Fragment() {
     }
 
     private fun addDrugCard(medication: Medications) {
-        var new = DrugCard(this.context!!)
+        var newCard = DrugCard(this.context!!)
 
-        new.medicationNameText.text = medication.name
-        new.medicationDueText.text = medication.dosage
+        newCard.nameText.text = medication.name
+        newCard.altText.text = medication.dosage
 
-        new.medicationLogButton.setOnClickListener {
+        newCard.button.setOnClickListener {
             //Edit drug settings
         }
-        new.medicationLogButton.text = "Edit"
-        new.medicationLogButton.layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT
-        new.medicationLogButton.visibility = View.VISIBLE
+        newCard.button.text = "Edit"
+        newCard.button.layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT
+        newCard.button.visibility = View.VISIBLE
         
-        stack.addView(new)
+        stack.addView(newCard)
     }
 
     private fun createMedicationData(drugName: String, drugDose: String) {

--- a/app/src/main/res/layout/drug_card.xml
+++ b/app/src/main/res/layout/drug_card.xml
@@ -55,7 +55,7 @@
                 app:layout_constraintStart_toEndOf="@+id/cardView">
 
                 <TextView
-                    android:id="@+id/medicationDue"
+                    android:id="@+id/altText"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="8:00 AM"
@@ -64,7 +64,7 @@
                     app:layout_constraintStart_toStartOf="parent" />
 
                 <TextView
-                    android:id="@+id/medicationLate"
+                    android:id="@+id/lateText"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
@@ -73,11 +73,11 @@
                     android:textColor="@color/colorRed"
 
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@+id/medicationDue" />
+                    app:layout_constraintStart_toEndOf="@+id/altText" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
-                android:id="@+id/medicationName"
+                android:id="@+id/nameText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
@@ -88,7 +88,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                android:id="@+id/medicationCountdownLabel"
+                android:id="@+id/countdownLabel"
                 android:layout_width="132dp"
                 android:layout_height="32dp"
                 android:layout_marginTop="20dp"
@@ -100,7 +100,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <Button
-                android:id="@+id/logButton"
+                android:id="@+id/button"
                 android:layout_width="68dp"
                 android:layout_height="48dp"
                 android:layout_marginTop="8dp"
@@ -118,7 +118,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <ImageView
-                android:id="@+id/medicationDoneImage"
+                android:id="@+id/doneImage"
                 android:layout_width="80dp"
                 android:layout_height="40dp"
                 android:layout_marginTop="12dp"


### PR DESCRIPTION
Component IDs were unnecessarily long (most of them were prefaced with "medication"), the "log button" is no longer just for logging, and the "due" text is now also used for dosage in the drug list, so IDs and variables were renamed accordingly.