### PR TITLE
Medication info text editing

### DIFF
--- a/app/src/main/java/com/pillpals/pillbuddies/ui/medications/medication_info/MedicationInfoFragment.kt
+++ b/app/src/main/java/com/pillpals/pillbuddies/ui/medications/medication_info/MedicationInfoFragment.kt
@@ -7,6 +7,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.LinearLayout.LayoutParams
+import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.viewpager.widget.ViewPager
@@ -24,7 +27,7 @@ class MedicationInfoFragment : Fragment() {
 
     private lateinit var realm: Realm
 
-    private var tabFragments: List<Fragment> = mutableListOf(
+    private var tabFragments: List<MedicationInfoTextFragment> = mutableListOf(
         MedicationInfoTextFragment(),
         MedicationInfoTextFragment(),
         MedicationInfoTextFragment(),
@@ -37,6 +40,11 @@ class MedicationInfoFragment : Fragment() {
         "Reviews"
     )
     private lateinit var tabPagerAdapter: TabPagerAdapter
+
+    private var textParams : LayoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+    private var textTopMargin = 16
+    private var headerSize = 20f
+    private var bodySize = 16f
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -51,6 +59,9 @@ class MedicationInfoFragment : Fragment() {
 
         tabPagerAdapter = TabPagerAdapter(activity!!.supportFragmentManager)
         tabViewPager.adapter = tabPagerAdapter
+        tabViewPager.offscreenPageLimit = 3
+
+        textParams.topMargin = textTopMargin
 
         addButton.setOnClickListener {
             val intent = Intent(context, AddDrugActivity::class.java)
@@ -58,6 +69,37 @@ class MedicationInfoFragment : Fragment() {
         }
 
         return view
+    }
+
+    //Assumes that the headers and bodyText lists are ordered and have indices that correspond with each other 1:1
+    private fun setTabText(tabIndex: Int, headers: List<String>, bodyText: List<String>) {
+        var layout: LinearLayout = tabFragments[tabIndex].layout
+        resetText(layout)
+        for ((index, headerText) in headers.withIndex()) {
+            addHeader(layout, headerText)
+            addBody(layout, bodyText[index])
+        }
+    }
+
+    private fun resetText(layout: ViewGroup) {
+        layout.removeAllViews()
+    }
+
+    private fun addHeader(layout: ViewGroup, text: String) {
+        appendText(layout, text, headerSize)
+    }
+
+    private fun addBody(layout: ViewGroup, text: String) {
+        appendText(layout, text, bodySize)
+    }
+
+    private fun appendText(layout: ViewGroup, text: String, fontSize: Float) {
+        var newView = TextView(context)
+        newView.text = text
+        newView.textSize = fontSize
+        newView.layoutParams = textParams
+
+        layout.addView(newView)
     }
 
     private inner class TabPagerAdapter(fm: FragmentManager) : FragmentStatePagerAdapter(fm) {

--- a/app/src/main/java/com/pillpals/pillbuddies/ui/medications/medication_info/MedicationInfoTextFragment.kt
+++ b/app/src/main/java/com/pillpals/pillbuddies/ui/medications/medication_info/MedicationInfoTextFragment.kt
@@ -5,17 +5,22 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 
 import com.pillpals.pillbuddies.R
 import io.realm.Realm
 
 class MedicationInfoTextFragment : Fragment() {
 
+    public lateinit var layout: LinearLayout
+
     private lateinit var realm: Realm
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         val view = inflater!!.inflate(R.layout.fragment_medication_info_text, container,false)
+
+        layout = view!!.findViewById(R.id.textLayout)
 
         realm = Realm.getDefaultInstance()
 

--- a/app/src/main/res/layout/fragment_medication_info_text.xml
+++ b/app/src/main/res/layout/fragment_medication_info_text.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/textLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/header1"
@@ -16,8 +17,8 @@
         android:id="@+id/text1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/header1"
         android:layout_marginTop="8dp"
         android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
         android:textSize="16sp" />
-</RelativeLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Added some helper functions for resetting and editing the text in the tabs on the medication information screen.  They're not in use yet but they'll be handy when we start populating the tabs with real information.